### PR TITLE
Skip the single unit test on CI, cutting build time in half

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,7 @@ jobs:
         run: |
           cargo install --locked --version=0.11.2 cargo-pgrx --debug --force
           cargo pgrx init --${{ matrix.pg }} download
-      - name: Run unit tests
-        run: cd plprql && echo "\q" | cargo pgrx run ${{ matrix.pg }} && cargo test --no-default-features --features ${{ matrix.pg }}
-      - name: Run integration tests
+      - name: Run tests
         run: cd plprql && echo "\q" | cargo pgrx run ${{ matrix.pg }} && cd ../plprql-tests && cargo test --no-default-features --features ${{ matrix.pg }}
   Install:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The unit test is just a sanity check testing prql, which has extensive test coverage anyway